### PR TITLE
Add fits to the path rather than copying fits into /usr/local. Fixes #9

### DIFF
--- a/install_scripts/fits.sh
+++ b/install_scripts/fits.sh
@@ -9,8 +9,11 @@ fi
 
 DOWNLOAD_URL="http://projects.iq.harvard.edu/files/fits/files/fits-${FITS_VERSION}.zip"
 cd $DOWNLOAD_DIR
-sudo curl $DOWNLOAD_URL > fits.zip
+if [ ! -f "fits.zip" ]; then
+  sudo curl $DOWNLOAD_URL > fits.zip
+fi
 unzip fits.zip
 chmod a+x fits-$FITS_VERSION/*.sh
 cd fits-$FITS_VERSION/
-sudo mv *.properties *.sh lib tools xml /usr/local/bin
+FITS_PATH="${DOWNLOAD_DIR}/fits-${FITS_VERSION}"
+echo "PATH=\${PATH}:$FITS_PATH" >> /home/vagrant/.bashrc


### PR DESCRIPTION
Also, don't download if it already exists.
