### PR TITLE
Fix line endings for Windows hosts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# For any shell scripts (.sh), ensure LF (Unix) line endings are ALWAYS kept
+# (even on Windows), as these are shell provisioning scripts
+*.sh text eol=lf
+# Same for the 'config' script
+install_scripts/config text eol=lf


### PR DESCRIPTION
This PR adds a `.gitattributes` settings file which allows this project to build properly on Windows host machines.  Essentially, everything under `install_scripts` must retain its Unix line endings, or else the Vagrant provisioning throws strange shell script errors.

The addition of this `.gitattributes` file allows the `vagrant up` to succeed for me (I'm running Windows 10).  It shouldn't have any affect on others running either Mac OSX or Linux hosts.
