### PR TITLE
Install Lerna / Hydra-in-a-box alongside CC and Sufia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hydra-vagrant
 
-A Vagrant environment to quickly setup current [CurationConcerns](https://github.com/projecthydra/curation_concerns) or [Sufia](https://github.com/projecthydra/sufia) applications.
+A Vagrant environment to quickly setup current [CurationConcerns](https://github.com/projecthydra/curation_concerns), [Sufia](https://github.com/projecthydra/sufia) or [Lerna / Hydra-in-a-box](https://github.com/projecthydra-labs/lerna) applications.
 
 ## Requirements
 
@@ -17,9 +17,10 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
 
 ## Using the App
 
-* The Vagrant contains two demo apps:
+* The Vagrant contains three demo apps:
   * CurationConcerns: `/home/vagrant/curation-concerns-demo`
   * Sufia: `/home/vagrant/sufia-demo`
+  * Lerna / Hydra-in-a-box: `/home/vagrant/lerna-demo`
 * Once connected to the Vagrant VM, change into the app directory and run the demo.
   e.g., for CurationConcerns: `cd curation-concerns-demo; rake demo`
 * Access the app at [http://localhost:3000](http://localhost:3000).
@@ -30,8 +31,8 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
 
 ## Environment
 
-* Ubuntu 14.04 64-bit base machine
-* [CurationConcerns](https://github.com/projecthydra/curation_concerns) or [Sufia](https://github.com/projecthydra/sufia): [http://localhost:3000](http://localhost:3000)
+* Ubuntu 16.04 64-bit base machine
+* [CurationConcerns](https://github.com/projecthydra/curation_concerns), [Sufia](https://github.com/projecthydra/sufia) or [Lerna](https://github.com/projecthydra-labs/lerna): [http://localhost:3000](http://localhost:3000)
 * [Solr 6.2.0](http://lucene.apache.org/solr/): [http://localhost:8983/solr/](http://localhost:8983/solr/)
 * [Fedora 4.6.0](http://fedorarepository.org/): [http://localhost:8984/](http://localhost:8984/)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "./install_scripts/bootstrap.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/java.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/ruby.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/postgres.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/fits.sh", args: shared_dir, privileged: false
   config.vm.provision "shell", path: "./install_scripts/demo-app.sh", args: shared_dir, privileged: false
 

--- a/install_scripts/demo-app.sh
+++ b/install_scripts/demo-app.sh
@@ -37,3 +37,12 @@ rails generate sufia:install -f -q
 rails generate sufia:work Work -q
 rake db:migrate
 echo "$DEMO_TASK" >> Rakefile
+
+echo "Creating Lerna (Hydra-in-a-box) demo in ${HOME}/lerna-demo"
+cd
+git clone https://github.com/projecthydra-labs/lerna.git lerna-demo
+cd lerna-demo
+bundle install --quiet
+rake db:create
+rake db:migrate
+echo "$DEMO_TASK" >> Rakefile

--- a/install_scripts/postgres.sh
+++ b/install_scripts/postgres.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Installing PostgreSQL database (requirement for Lerna)"
+
+# Necessary PostgreSQL packages
+PACKAGES="postgresql-common postgresql libpq-dev"
+sudo apt-get -y install $PACKAGES
+
+# As our vagrant box defaults to a user named 'ubuntu',
+# we have to create a corresponding 'ubuntu' SUPERUSER in PostgreSQL
+sudo -u postgres createuser ubuntu --superuser


### PR DESCRIPTION
This PR provides a basic demo installation of Lerna alongside Sufia and CC.
- Adds a `postgres.sh` to install/setup the PostgreSQL requirement for [Lerna](https://github.com/projecthydra-labs/lerna/)
- Installs Lerna to `~/lerna-demo` by cloning its Github repo
- Currently, it has to append a new 'demo' task to Lerna's default `Rakefile`. But, assuming https://github.com/projecthydra/hydra-head/pull/381 is resolved in some way, this may be later removed in favor of setting an environment variable.
- Updated the README. 

After the `vagrant up`, Lerna can by started in the same manner as Sufia and CC:

```
cd ~/lerna-demo
rake demo
```

This all works, but I will admit it slows down the initial `vagrant up`, as now 3 applications are installed/built.

This brings up the question of whether there's any interest in making `hydra-vagrant` more configurable (so you can select which application(s) you want to install via a configuration setting or similar). If there _is_ such interest, it shouldn't be difficult to achieve (and I can turn this into a new ticket/issue).  

Just as an example, DSpace's [`vagrant-dspace`](https://github.com/DSpace/vagrant-dspace/) project has a [`default.yaml`](https://github.com/DSpace/vagrant-dspace/blob/master/config/default.yaml) config file that can be used to tweak the VM's settings/setup.  `hydra-vagrant` need not be anywhere near as complex, but some very basic configs could be enabled to allow you to choose which application(s) to install, or tweak other commonly tweaked settings for demos, etc.
