### PR TITLE
Install Hyrax and Hyku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hydra-vagrant
+# samvera-vagrant
 
-A Vagrant environment to quickly setup current [CurationConcerns](https://github.com/projecthydra/curation_concerns) or [Sufia](https://github.com/projecthydra/sufia) applications.
+A Vagrant environment to quickly setup current [Hyrax](http://hyr.ax/) or [Hyku](https://github.com/samvera-labs/hyku) applications.
 
 ## Requirements
 
@@ -9,8 +9,8 @@ A Vagrant environment to quickly setup current [CurationConcerns](https://github
 
 ## Setup
 
-1. `git clone https://github.com/projecthydra-labs/hydra-vagrant.git`
-2. `cd hydra-vagrant`
+1. `git clone https://github.com/samvera-labs/samvera-vagrant.git`
+2. `cd samvera-vagrant`
 3. `vagrant up`
 
 You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localhost`
@@ -18,22 +18,23 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
 ## Using the App
 
 * The Vagrant contains two demo apps:
-  * CurationConcerns: `/home/ubuntu/curation-concerns-demo`
-  * Sufia: `/home/ubuntu/sufia-demo`
+  * Hyrax: `/home/ubuntu/hyrax-demo`
+  * Hyku: `/home/ubuntu/hyku-demo`
 * Once connected to the Vagrant VM, change into the app directory and run the demo.
-  e.g., for CurationConcerns: `cd curation-concerns-demo; rake demo`
+  e.g., for Hyrax: `cd hyrax-demo; rake demo`
 * Access the app at [http://localhost:3000](http://localhost:3000).
-* To setup an initial user account:
+* To setup an initial user account in Hyrax:
   * Click "Log In" in the upper right, and then "Sign up" in the login form.
   * Enter your username and password, and click "Sign up" to create your account and sign in.
-* Once signed in, you can create content by clicking the "+" button in the upper right.
+  * Once signed in, you can create content by clicking the "Share Your Work" button on the homepage.
+* See the [Hyku documentation](https://wiki.duraspace.org/display/hyku/Hyku+Product+Beta+-+Frequently+Asked+Questions) for more on how to get started on Hyku
 
 ## Environment
 
-* Ubuntu 14.04 64-bit base machine
-* [CurationConcerns](https://github.com/projecthydra/curation_concerns) or [Sufia](https://github.com/projecthydra/sufia): [http://localhost:3000](http://localhost:3000)
-* [Solr 6.2.0](http://lucene.apache.org/solr/): [http://localhost:8983/solr/](http://localhost:8983/solr/)
-* [Fedora 4.6.0](http://fedorarepository.org/): [http://localhost:8984/](http://localhost:8984/)
+* Ubuntu 16.04 64-bit base machine
+* [Hyrax](https://github.com/samvera-labs/hyrax) or [Hyku](https://github.com/samvera-labs/hyku): [http://localhost:3000](http://localhost:3000)
+* [Solr 6.6.0](http://lucene.apache.org/solr/): [http://localhost:8983/solr/](http://localhost:8983/solr/)
+* [Fedora 4.7.1](http://fedorarepository.org/): [http://localhost:8984/](http://localhost:8984/)
 
 ## Thanks
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,13 +6,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.hostname = "curation-concerns"
+  config.vm.hostname = "samvera"
 
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000 # Rails
-  config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr 5.4
-  config.vm.network :forwarded_port, guest: 8984, host: 8984 # Fedora 4.5
+  config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr
+  config.vm.network :forwarded_port, guest: 8984, host: 8984 # Fedora
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
@@ -23,7 +23,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "./install_scripts/bootstrap.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/java.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/ruby.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/postgres.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/multitenancy.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/fits.sh", args: shared_dir, privileged: false
   config.vm.provision "shell", path: "./install_scripts/demo-app.sh", args: shared_dir, privileged: false
-
 end

--- a/install_scripts/config
+++ b/install_scripts/config
@@ -10,4 +10,4 @@ if [ ! -d $DOWNLOAD_DIR ]; then
   mkdir $DOWNLOAD_DIR
 fi
 
-FITS_VERSION=0.10.0
+FITS_VERSION=1.0.5

--- a/install_scripts/demo-app.sh
+++ b/install_scripts/demo-app.sh
@@ -15,25 +15,36 @@ task :demo do
   end
 end"
 
-echo "Creating CurationConcerns demo in ${HOME}/curation-concerns-demo"
+DEFAULT_ADMIN_SET_TASK="
+task :default_admin_set do
+  with_server :development do
+    Rake::Task['hyrax:default_admin_set:create'].invoke
+    exit
+  end
+end
+"
+
+echo "Creating Hyrax demo in ${HOME}/hyrax-demo"
 cd
-rails new curation-concerns-demo --skip-spring
-cd curation-concerns-demo
-echo "gem 'curation_concerns', '1.5.0'" >> Gemfile
+rails new hyrax-demo --skip-spring
+cd hyrax-demo
+echo "gem 'hyrax', github: 'samvera/hyrax'" >> Gemfile
 bundle install --quiet
-rails generate curation_concerns:install -f -q
-rails generate curation_concerns:work Book -q
-rake db:migrate
+rails generate hyrax:install -f -q
+rails db:migrate
+rails hyrax:workflow:load
+echo "$DEFAULT_ADMIN_SET_TASK" >> Rakefile
+rails default_admin_set
+rails generate hyrax:work Image -q
+rails generate hyrax:work Book -q
 echo "$DEMO_TASK" >> Rakefile
 
-echo "Creating Sufia demo in ${HOME}/sufia-demo"
+echo "Creating Hyku demo in ${HOME}/hyku-demo"
 cd
-rails new sufia-demo --skip-spring
-cd sufia-demo
-echo "gem 'sufia', github: 'projecthydra/sufia', branch: :master" >> Gemfile
-echo "gem 'flipflop', github: 'jcoyne/flipflop', branch: :hydra" >> Gemfile
+git clone https://github.com/samvera-labs/hyku.git hyku-demo
+cd hyku-demo
+sed -i -e 's/enabled: false/enabled: true/' config/settings.yml
 bundle install --quiet
-rails generate sufia:install -f -q
-rails generate sufia:work Work -q
+rake db:create
 rake db:migrate
 echo "$DEMO_TASK" >> Rakefile

--- a/install_scripts/multitenancy.sh
+++ b/install_scripts/multitenancy.sh
@@ -1,0 +1,11 @@
+## Set up multitenancy for Hyku
+
+# dnsmasq (for resolving localhost subdomains)
+apt-get -y install dnsmasq
+
+echo "address=/localhost/127.0.0.1" > /etc/dnsmasq.d/localhost.conf
+
+sed -i -e 's/#prepend domain-name-servers 127.0.0.1;/prepend domain-name-servers 127.0.0.1;/' /etc/dhcp/dhclient.conf
+
+service dnsmasq restart
+dhclient

--- a/install_scripts/postgres.sh
+++ b/install_scripts/postgres.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Installing PostgreSQL database (requirement for Hyku)"
+
+# Necessary PostgreSQL packages
+PACKAGES="postgresql-common postgresql libpq-dev"
+sudo apt-get -y install $PACKAGES
+
+# As our vagrant box defaults to a user named 'ubuntu',
+# we have to create a corresponding 'ubuntu' SUPERUSER in PostgreSQL
+sudo -u postgres createuser ubuntu --superuser


### PR DESCRIPTION
This commit removes Sufia and CurationConcerns from the vagrant installation and adds Hyrax and Hyku. It includes the following changes:

 * Rename from hydra-vagrant to samvera-vagrant
 * Update FITS to 1.0.5
 * Remove support for installing Sufia and CC
 * Add support for installing Hyrax and Hyku
 * Add multi-tenancy for Hyku
 * Reflect changes in README