### PR TITLE
Add developer friendly configs/tools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,27 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 3000, host: 3000 # Rails
   config.vm.network :forwarded_port, guest: 8983, host: 8983 # Solr
   config.vm.network :forwarded_port, guest: 8984, host: 8984 # Fedora
+  config.vm.network :forwarded_port, guest: 8888, host: 8888 # Jasmine Tests
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
   end
+
+  # Check our system locale -- make sure it is set to UTF-8
+  # This also means we need to run 'dpkg-reconfigure' to avoid "unable to re-open stdin" errors (see http://serverfault.com/a/500778)
+  # For now, we have a hardcoded locale of "en_US.UTF-8"
+  locale = "en_US.UTF-8"
+  config.vm.provision :shell, :inline => "echo 'Setting locale to UTF-8 (#{locale})...' && locale | grep 'LANG=#{locale}' > /dev/null || update-locale --reset LANG=#{locale} && dpkg-reconfigure -f noninteractive locales"
+
+  # Turn off annoying console bells/beeps in Ubuntu (only if not already turned off in /etc/inputrc)
+  config.vm.provision :shell, :inline => "echo 'Turning off console beeps...' && grep '^set bell-style none' /etc/inputrc || echo 'set bell-style none' >> /etc/inputrc"
+
+  # Turn on SSH forwarding (so that 'vagrant ssh' has access to your local SSH keys, and you can use your local SSH keys to access GitHub, etc.)
+  config.ssh.forward_agent = true
+
+  # Prevent annoying "stdin: is not a tty" errors from displaying during 'vagrant up'
+  # See also https://github.com/mitchellh/vagrant/issues/1673#issuecomment-28288042
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
   shared_dir = "/vagrant"
 

--- a/install_scripts/ruby.sh
+++ b/install_scripts/ruby.sh
@@ -3,7 +3,7 @@
 echo "Setting up ruby environment"
 
 # pre-requisites
-PACKAGES="imagemagick libreadline-dev libyaml-dev libsqlite3-dev nodejs zlib1g-dev libsqlite3-dev nodejs redis-server"
+PACKAGES="imagemagick libreadline-dev libyaml-dev libsqlite3-dev nodejs zlib1g-dev libsqlite3-dev redis-server"
 sudo apt-get -y install $PACKAGES
 
 # ruby and the development libraries (so we can compile nokogiri, kgio, etc)
@@ -12,3 +12,7 @@ sudo apt-get -y install ruby ruby-dev
 # gems
 GEMS="bundler rails"
 sudo gem install $GEMS --no-ri --no-rdoc
+
+# For testing, we need phantomjs. Install it via NPM/Node
+sudo apt-get -y install npm nodejs-legacy
+sudo npm install -g phantomjs-prebuilt


### PR DESCRIPTION
This PR makes some minor enhancements to `samvera-vagrant` to make it more developer friendly (for folks who want to use vagrant for development work):

1. Preinstall PhantomJS
2. Open up Jasmine's port (8888) to make it accessible on host machine
3. Enable SSH forwarding
4. Minor preconfiguration of Ubuntu (configure system locale, turn off console beeps, etc)

As someone who uses `samvera-vagrant` for occasional development/testing, I've found each of these to be useful additions.