### PR TITLE
Lock rails5.1 fix bundle: add libcurl dep + replace 'ubuntu' with 'vagrant' user

### DIFF
--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -22,5 +22,5 @@ apt-get -y install build-essential
 # Git vim
 apt-get -y install git vim
 
-# Wget, curl and unzip
-apt-get -y install wget curl unzip
+# Wget, curl, libcurl and unzip
+apt-get -y install wget curl libcurl3 unzip

--- a/install_scripts/postgres.sh
+++ b/install_scripts/postgres.sh
@@ -6,6 +6,6 @@ echo "Installing PostgreSQL database (requirement for Hyku)"
 PACKAGES="postgresql-common postgresql libpq-dev"
 sudo apt-get -y install $PACKAGES
 
-# As our vagrant box defaults to a user named 'ubuntu',
-# we have to create a corresponding 'ubuntu' SUPERUSER in PostgreSQL
-sudo -u postgres createuser ubuntu --superuser
+# As our vagrant box defaults to a user named 'vagrant',
+# we have to create a corresponding 'vagrant' SUPERUSER in PostgreSQL
+sudo -u postgres createuser vagrant --superuser


### PR DESCRIPTION
This should resolve https://github.com/samvera-labs/samvera-vagrant/issues/28 and the `Could not open library 'libcurl.so': libcurl.so: cannot open shared object file: No such file or directory.` message seen after vagrant-upping.